### PR TITLE
fix: reorder textinput props

### DIFF
--- a/src/components/TextAreaResizable/index.tsx
+++ b/src/components/TextAreaResizable/index.tsx
@@ -69,6 +69,7 @@ export const TextAreaResizable = (props: TextAreaResizableProps) => {
 
   return (
     <TextInput
+      {...props}
       style={{
         ...(props.style as Object),
         padding: 4,
@@ -84,7 +85,6 @@ export const TextAreaResizable = (props: TextAreaResizableProps) => {
       onContentSizeChange={handleContentSizeChange}
       editable={props.editable ?? !disabled}
       placeholderTextColor={props?.placeholderTextColor ?? 'lightgray'}
-      {...props}
     />
   )
 }


### PR DESCRIPTION
Fixing error with styles... problem was, only were showing which were included as props, not which were inside the component.